### PR TITLE
feat: opt-in allow_missing_content_type for SSE responses

### DIFF
--- a/lib/ld-eventsource/client.rb
+++ b/lib/ld-eventsource/client.rb
@@ -108,7 +108,8 @@ module SSE
           logger: nil,
           socket_factory: nil,
           parse: true,
-          verify_ssl: true)
+          verify_ssl: true,
+          allow_missing_content_type: false)
       @uri = URI(uri)
       @stopped = Concurrent::AtomicBoolean.new(false)
 
@@ -119,6 +120,7 @@ module SSE
       @http_payload = http_payload
       @logger = logger || default_logger
       @parse = parse
+      @allow_missing_content_type = allow_missing_content_type
       http_client_options = {}
       unless verify_ssl
         http_client_options[:ssl] = { verify_mode: OpenSSL::SSL::VERIFY_NONE }
@@ -290,6 +292,9 @@ module SSE
             content_type = cxn.content_type.mime_type
             if content_type && content_type.start_with?("text/event-stream")
               return cxn  # we're good to proceed
+            elsif content_type.to_s.empty? && @allow_missing_content_type
+              # Some providers (e.g. Tinker) stream SSE without a Content-Type header.
+              return cxn
             else
               reset_http
               err = Errors::HTTPContentTypeError.new(content_type)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -203,6 +203,53 @@ EOT
     end
   end
 
+  def send_stream_content_without_content_type(res, content)
+    res.status = 200
+    res.chunked = true
+    rd, wr = IO.pipe
+    res.body = rd
+    wr.write(content)
+    res.header.delete("content-type")
+    wr
+  end
+
+  it "errors on missing content type by default" do
+    with_server do |server|
+      server.setup_response("/") do |req,res|
+        send_stream_content_without_content_type(res, simple_event_1_text)
+      end
+
+      error_sink = Queue.new
+      client = subject.new(server.base_uri, reconnect_time: reconnect_asap) do |c|
+        c.on_error { |error| error_sink << error }
+      end
+
+      with_client(client) do |c|
+        expect(error_sink.pop).to be_a(SSE::Errors::HTTPContentTypeError)
+      end
+    end
+  end
+
+  it "accepts missing content type when allow_missing_content_type is true" do
+    with_server do |server|
+      server.setup_response("/") do |req,res|
+        send_stream_content_without_content_type(res, simple_event_1_text)
+      end
+
+      event_sink = Queue.new
+      error_sink = Queue.new
+      client = subject.new(server.base_uri, reconnect_time: reconnect_asap, allow_missing_content_type: true) do |c|
+        c.on_event { |event| event_sink << event }
+        c.on_error { |error| error_sink << error }
+      end
+
+      with_client(client) do |c|
+        expect(event_sink.pop).to eq(simple_event_1)
+        expect(error_sink).to be_empty
+      end
+    end
+  end
+
   it "reconnects after read timeout" do
     events_body = simple_event_1_text
     with_server do |server|


### PR DESCRIPTION
### Why

Thinking Machines' Tinker OpenAI-compatible streaming endpoint returns `200` with **no Content-Type header**, so the spec-mandated `text/event-stream` check rejects the stream before reading any events. Upstream launchdarkly/ruby-eventsource has no bypass option.

This mirrors the patch already applied to gondor's vendored copy (surge-ai/gondor#39487), keeping this fork canonical with what gondor ships.

### What

- New opt-in `allow_missing_content_type:` kwarg (default `false`) on `SSE::Client`. When set, a blank/missing content type is accepted; a present-but-wrong content type (e.g. an HTML error page) still raises `HTTPContentTypeError`.
- Specs: missing content type still errors by default; passes with the flag. `spec/client_spec.rb`: 17 examples, 0 failures.

### History: this problem has come up before

This is the second time the strict content-type check has blocked a provider integration, so recording the first for posterity:

- **Mar 12, 2024** — the `jeffersonl--content-type-check` branch on this repo ("remove content type check" + two "log response" debug commits) was an experiment during the bard-ice streaming work: ICE models took 60–90s against Heroku's 30s cutoff, and streaming through the IPB proxy hit this same validation.
- **Mar 17, 2024** — surge-ai/gondor#12319 fought the request-side half of the same battle ("Remove some restrictive headers from proxy... so we are open to all content types").
- **Resolution back then**: the merged `BardIceChatStreamService` (surge-ai/gondor#12338) sidestepped `SSE::Client` entirely — plain `HTTParty.post` with fake streaming — so the check was never actually changed. Gondor's Gemfile only ever pinned `main`; the branch never shipped, and bard-ice kept fake streaming until its removal in May 2025 (surge-ai/gondor#22158).

This PR is the scoped version of that 2024 instinct: instead of deleting the check for every consumer, callers that knowingly talk to a non-compliant provider opt in per client, and everyone else keeps spec-compliant strictness. Once this merges, `jeffersonl--content-type-check` is superseded and can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
