### PR TITLE
fix: set a write timeout so requests survive one cross-border RTT

### DIFF
--- a/lib/ld-eventsource/client.rb
+++ b/lib/ld-eventsource/client.rb
@@ -149,6 +149,8 @@ module SSE
         .timeout({
           read: read_timeout,
           connect: connect_timeout,
+          # http.rb defaults this to 0.25s, which is under one cross-border RTT.
+          write: 30,
         })
       @cxn = nil
       @lock = Mutex.new


### PR DESCRIPTION
### Why

`Client#initialize` builds its HTTP client with only `read` and `connect` timeouts:

```ruby
HTTP::Client.new(http_client_options).timeout({ read: read_timeout, connect: connect_timeout })
```

Passing a Hash at all is what selects `HTTP::Timeout::PerOperation`, and that class fills in any key you omit from its own defaults — including `WRITE_TIMEOUT = 0.25`. So the request body write has silently been running on a **250 ms** budget while connect and read get 10 s and 300 s.

That default is fine for the `GET` streams this gem was originally written for, where there is no body to write. It is not fine for the `POST` support this fork added: `http.rb` writes headers and the entire body in a single `write_nonblock` (`http/request/writer.rb`), so on a fresh socket `:wait_writable` means the send buffer could not absorb the whole payload, and finishing the write then costs one full round trip waiting for the peer's first ACK.

We hit this in production against an endpoint measuring **227–238 ms RTT at 0% packet loss** — one round trip is ~92% of the entire write budget. It is not flakiness; the timeout is structurally below the path's ACK latency, so any body that overflows the send buffer fails deterministically with:

```
HTTP::TimeoutError: Write timed out after 0.25 seconds
```

101 of 107 such failures over 7 days carried exactly that message. Notably the affected requests have *small* bodies (~2 KB) while much larger bodies to nearby endpoints never fail — the controlling variable is RTT ÷ write_timeout, not body size. Body size only decides whether an ACK is needed at all.

### What

Sets `write: 30` in the timeout hash, sized in round trips rather than milliseconds.

Deliberately not a new `write_timeout:` keyword or `DEFAULT_WRITE_TIMEOUT` constant: that would widen `SSE::Client`'s public surface, and our consumer has no need for a per-stream override. Happy to make it configurable instead if you would rather the library expose it — say the word and I will push that version.

### Testing

- `rspec spec` → `111 examples, 0 failures`
- `rubocop --parallel` → `16 files inspected, no offenses detected`

Verified in the consuming app with a red/green reproduction that exercises the real socket path with no stubs — a real `Socket` with a shrunk `SO_RCVBUF` accepts the connection and then stops reading, forcing genuine non-writability:

```
RED   (before): timeout_options={read_timeout: 600, connect_timeout: 10}
                ERROR after 0.297s: HTTP::TimeoutError: Write timed out after 0.25 seconds
GREEN (after):  timeout_options={read_timeout: 600, write_timeout: 30, connect_timeout: 10}
                EVENT after 2.030s — survived an 8.1x stall and the stream completed
```

RED and GREEN were each 5/5 deterministic, and asserting RED against the patched gem correctly fails, so the assertion is not vacuous.

Paired with surge-ai/gondor#40263, which carries the identical two-line change in the vendored copy so the two stay byte-identical.